### PR TITLE
Fix summary page

### DIFF
--- a/apps/summary-page/index.js
+++ b/apps/summary-page/index.js
@@ -3,7 +3,7 @@
 const summary = require('hof-behaviour-summary-page');
 
 module.exports = {
-  name: 'summary page',
+  name: 'summary-page',
   baseUrl: '/summary-page-example',
   steps: {
     '/name': {


### PR DESCRIPTION
* Add a hyphen to the summary page so that it matches with the directory name