### PR TITLE
Amend Summary page base Url

### DIFF
--- a/apps/summary-page/index.js
+++ b/apps/summary-page/index.js
@@ -4,7 +4,7 @@ const summary = require('hof-behaviour-summary-page');
 
 module.exports = {
   name: 'summary-page',
-  baseUrl: '/summary-page-example',
+  baseUrl: '/summary-page',
   steps: {
     '/name': {
       fields: ['name'],


### PR DESCRIPTION
removing 'example' suffix so that the baseUrl is shorter and less for users to type